### PR TITLE
Add Dockerfile for firestore emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:latest
+
+WORKDIR /go/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+services:
+  web:
+    build: .
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/go/src/app
+    environment:
+      - FIRESTORE_EMULATOR_HOST=firestore:8001
+      - PROJECT_ID=dummy-project
+    depends_on:
+      - firestore
+  firestore:
+    build:
+      context: .
+      dockerfile: ./firestore/Dockerfile
+    volumes:
+      - firestore-data:/opt/data
+    command: "gcloud beta emulators firestore start --host-port=0.0.0.0:8001"
+
+volumes:
+  firestore-data:

--- a/firestore/Dockerfile
+++ b/firestore/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
+
+ARG FIRESTORE_EMULATOR_HOST_PORT="0.0.0.0:8001"
+VOLUME /opt/data
+
+EXPOSE 8001


### PR DESCRIPTION
This PR added Dockerfile for firestore emulator.
This portfolio will use firestore instead of RDBMS.